### PR TITLE
Update prod name for qsharp api from quantum

### DIFF
--- a/api/docfx.json
+++ b/api/docfx.json
@@ -42,7 +42,7 @@
     "externalReference": [],
     "globalMetadata": {
       "show_latex": true,
-      "ms.prod": "quantum",
+      "ms.prod": "qsharp",
       "ms.topic": "managed-reference",
       "ms.devlang":"qsharp",
       "searchScope": ["quantum", "q#", "qsharp"],


### PR DESCRIPTION
ms.prod name for qsharp API changed:
From: quantum
To: qsharp

**⚠ NOTE**:
This repository only contains automatically generated API documentation, and thus cannot accept pull requests.
If you would like to contribute to the API documentation in this repo, please see the [Quantum Development Kit contribution guide](https://docs.microsoft.com/azure/quantum/contributing-docs#contributing-to-the-api-references) to learn more.
