### PR TITLE
Add xref_query_tags so xref links will look in the /quantum docset

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -7,6 +7,9 @@
       "locale": "en-us",
       "monikers": [],
       "moniker_ranges": [],
+      "xref_query_tags": [
+        "/quantum"
+      ],
       "enable_xrefmap_share": true,
       "open_to_public_contributors": false,
       "type_mapping": {


### PR DESCRIPTION
xref links in the API docs that target the /quantum docset are not resolving. Previously, the API docset and the quantum docset were built from the same repo. Per the [repo admin guidance](https://review.docs.microsoft.com/en-us/help/onboard/admin/xref-service-vs-local-xref-files?branch=master#priority-of-xref-resolve-logic), adding the query tag will allow the xref service to look in the /quantum repo to resolve xref links. 


